### PR TITLE
Port manual dhcp changes to Puppet

### DIFF
--- a/cluster/corecp/role/dhcp.yaml
+++ b/cluster/corecp/role/dhcp.yaml
@@ -73,7 +73,7 @@ dhcp::pools:
     mask: "255.255.255.0"
     gateway: "139.229.163.254"
     range:
-      - "139.229.163.1 139.229.163.254"
+      - "139.229.163.1 139.229.163.253"
     search_domains: *dnsdomain
 dhcp::hosts:
   M207-gs-plotter-01.cp.cl.lsst.org:
@@ -108,3 +108,10 @@ dhcp::hosts:
     comment: "Main Wireless Controller Summit"
     mac: "40:CE:24:F7:E2:73"
     ip: "139.229.162.61"
+  conference-voip:
+    comment: "Summit conference room VOIP"
+    mac: "52:54:00:F5:63:7E"
+    ip: "139.229.163.200"
+  dns1:  # XXX: Check if this reservation should live in foreman or should be a static IP address.
+    mac: "52:54:00:F5:63:7E"
+    ip: "139.229.162.22"

--- a/cluster/corecp/role/dhcp.yaml
+++ b/cluster/corecp/role/dhcp.yaml
@@ -67,8 +67,6 @@ dhcp::pools:
     gateway: "139.229.162.126"
     range:
       - "139.229.162.2 139.229.162.89"
-      - "139.229.162.108 139.229.162.109"
-      - "139.229.162.122 139.229.162.123"
     search_domains: *dnsdomain
 dhcp::hosts:
   M207-gs-plotter-01.cp.cl.lsst.org:

--- a/cluster/corecp/role/dhcp.yaml
+++ b/cluster/corecp/role/dhcp.yaml
@@ -1,8 +1,8 @@
 ---
 dhcp::interfaces:
   - "ens192"
-dhcp::default_lease_time: 43200
-dhcp::max_lease_time: 86400
+dhcp::default_lease_time: 3600
+dhcp::max_lease_time: 3600
 dhcp::authoritative: false
 dhcp::ddns_update_style: "none"
 dhcp::logfacility: "daemon"

--- a/cluster/corecp/role/dhcp.yaml
+++ b/cluster/corecp/role/dhcp.yaml
@@ -68,6 +68,13 @@ dhcp::pools:
     range:
       - "139.229.162.2 139.229.162.89"
     search_domains: *dnsdomain
+  users_163:
+    network: "139.229.163.0"
+    mask: "255.255.255.0"
+    gateway: "139.229.163.254"
+    range:
+      - "139.229.163.1 139.229.163.254"
+    search_domains: *dnsdomain
 dhcp::hosts:
   M207-gs-plotter-01.cp.cl.lsst.org:
     comment: "Plotter configuration: https://jira.lsstcorp.org/browse/IHS-1600"


### PR DESCRIPTION
This pull request ports changes made on dhcp1 back into Puppet.

On 2019-11-21 we experienced issues where user devices were assigned IP
addresses that were supposed to be owned by services, causing those services to
be unavailable. We had a double whammy in terms of outages because both DNS and
Puppet were affected; the DNS issues caused significant user issues that needed
immediate resolution and the Puppet outages prevented us from pushing fixes via Puppet.

At the time we resolved the issue by manually editing DHCP configurations and renumbering critical hosts with IP addresses that weren't assigned in the pool. This got us through the immediate issue and gave us enough operating ability to create a new pool for hosts, but left a blob of configuration that was not managed via Puppet.

This pull request pulls the changes from dhcp1 into Puppet as-is. At the moment dhcp1 is running puppet in noop; I'd like to be on-site before applying any changes.

Once this PR is merged we should talk about what hosts should have static IP addresses. Given the issues we just experienced I am of the opinion that Foreman and DNS should have static IP addresses that can't be given out by DHCP - when DHCP went sideways and re-assigned those IP addresses we were pretty dead in the water. @jhoblitt what's your take on static IP addresses for these hosts?