### PR TITLE
(maint) Remove dead rsyslog hiera lookups

### DIFF
--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -23,12 +23,6 @@ chrony::servers:
   - "1.cl.pool.ntp.org"
   - "1.south-america.pool.ntp.org"
 
-# Monitoring Configuration
-# Remote Logging and Graylog Configuration
-rsyslog_host: "139.229.136.244"
-rsyslog_port: "5514"
-rsyslog_proto: "udp"
-rsyslog_patterns: "*.info;mail.none;authpriv.none;cron.none"
 rsyslog::client::global_config:
   workDirectory:
     value: "/var/log"

--- a/site/ls.yaml
+++ b/site/ls.yaml
@@ -27,15 +27,7 @@ lsst_firewall_default_sources:
   - "139.229.162.0/24"
   - "140.252.32.0/23"
   - "140.252.90.64/27"  # VPN
-#=============================================================================
-# Monitoring Configuration
-#=============================================================================
-# Remote Logging and Graylog Configuration
-#=============================================================================
-rsyslog_host: "139.229.136.244"
-rsyslog_port: "5514"
-rsyslog_proto: "udp"
-rsyslog_patterns: "*.info;mail.none;authpriv.none;cron.none"
+
 rsyslog::client::global_config:
   workDirectory:
     value: "/var/log"

--- a/site/tu.yaml
+++ b/site/tu.yaml
@@ -36,16 +36,6 @@ lsst_firewall_default_sources:
   - 139.229.136.0/24  # La Serena Base
 
 #=============================================================================
-# Monitoring Configuration
-#=============================================================================
-# Remote Logging and Graylog Configuration
-#=============================================================================
-rsyslog_host: "gs-graylog-node-01.po.us.lsst.org"
-rsyslog_port: "5514"
-rsyslog_proto: "udp"
-rsyslog_patterns: "*.info;mail.none;authpriv.none;cron.none"
-
-#=============================================================================
 # Telegraf common configuration
 
 monitoring_enabled: true


### PR DESCRIPTION
Commit dc882b82b in lsst-it/lsst-itconf removed the explicit lookups to
the 'rsyslog_*' entries. This commit removes the matching entries from
hiera.