### PR TITLE
Re-add graylog profile to gs-graylog-node-01

### DIFF
--- a/node/gs-graylog-node-01.cp.lsst.org.yaml
+++ b/node/gs-graylog-node-01.cp.lsst.org.yaml
@@ -1,0 +1,2 @@
+---
+mongodb::globals::version: "3.4.21-1.el7"

--- a/role/graylog.yaml
+++ b/role/graylog.yaml
@@ -1,7 +1,6 @@
 ---
 classes:
   - "profile::core::common"
-  - "profile::default"
   - "profile::it::graylog"
 mongodb::globals::version: "3.6.13"
 elasticsearch_xms: "2048m"

--- a/role/graylog.yaml
+++ b/role/graylog.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "profile::core::common"
   - "profile::default"
   - "profile::it::graylog"
 mongodb::globals::version: "3.6.13"


### PR DESCRIPTION
This pull request re-adds the `profile::it::graylog` class to
gs-graylog-node-01. This class was in use before the node was migrated to
foreman, and having a little bit of Puppet management is better than no
management at all.