### PR TITLE
role/k3s: disable iptables firewall

### DIFF
--- a/role/k3s.yaml
+++ b/role/k3s.yaml
@@ -9,3 +9,4 @@ docker::version: "19.03.4"
 # ipa docker group is 70014
 docker::socket_group: "70014"
 docker::socket_override: true
+firewall::ensure: "stopped"


### PR DESCRIPTION
The default iptables rules drop traffic inbound for k3s. We disable the
firewall for the corecp cluster and might as well do it for all k3s
nodes.