### PR TITLE
IT-1545: sync DHCP and resolv.conf entries

### DIFF
--- a/cluster/corecp/role/dhcp.yaml
+++ b/cluster/corecp/role/dhcp.yaml
@@ -7,20 +7,13 @@ dhcp::authoritative: false
 dhcp::ddns_update_style: "none"
 dhcp::logfacility: "daemon"
 # dnsdomain requires an array but only uses the first element to set the domain
-dhcp::dnsdomain: &dnsdomain
-  - "cp.lsst.org"
-  - "cp.cl.lsst.org"
-  - "cl.lsst.org"
-  - "lsst.org"
-  - "lsst.local"
-dhcp::nameservers:
-  - "139.229.162.22"
-  - "139.229.162.87"
-  - "208.67.222.222"
-dhcp::ntpservers:
-  - "ntp.shoa.cl"
-  - "1.cl.pool.ntp.org"
-  - "1.south-america.pool.ntp.org"
+
+# The following keys are defined in `site/cp.yaml` as they are shared between
+# the `dhcp`, `resolv_conf`, and `chrony` classes:
+# - dhcp::dnsdomain
+# - dhcp::nameservers
+# - dhcp::ntpservers
+
 dhcp::bootp: true
 dhcp::pxeserver: "139.229.162.45"  # foreman
 # theforeman/dhcp 5.0.1 only supports `option domain-search` per pool
@@ -30,7 +23,7 @@ dhcp::pools:
     mask: "255.255.255.192"
     gateway: "139.229.158.254"
     range: "139.229.158.193 139.229.158.253"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   contractors_cp:
     network: "139.229.191.0"
     mask: "255.255.255.128"
@@ -38,38 +31,38 @@ dhcp::pools:
     range:
       - "139.229.191.1 139.229.191.64"  # .65: dimm-laptop
       - "139.229.191.66 139.229.191.100"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   guests_cp:
     network: "139.229.191.128"
     mask: "255.255.255.128"
     gateway: "139.229.191.254"
     range: "139.229.191.129 139.229.191.239"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   guests_ls:
     network: "139.229.159.128"
     mask: "255.255.255.128"
     gateway: "139.229.159.254"
     range: "139.229.159.129 139.229.159.253"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   tcontractors_ls:
     network: "139.229.158.128"
     mask: "255.255.255.192"
     gateway: "139.229.158.190"
     range: "139.229.158.129 139.229.158.189"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   ucontractors_ls:
     network: "139.229.159.0"
     mask: "255.255.255.128"
     gateway: "139.229.159.126"
     range: "139.229.159.1 139.229.159.125"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   users:
     network: "139.229.162.0"
     mask: "255.255.255.128"
     gateway: "139.229.162.126"
     range:
       - "139.229.162.28 139.229.162.37"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   users_163:
     network: "139.229.163.0"
     mask: "255.255.255.0"
@@ -78,14 +71,14 @@ dhcp::pools:
       - "139.229.163.1 139.229.163.239"
       # 139.229.163.240/28 is reserved for the network gateway and static
       # IP addresses.
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   control_auxtel:
     network: "139.229.170.0"
     mask: "255.255.255.0"
     gateway: "139.229.170.254"
     range:
       - "139.229.170.64 139.229.170.95"
-    search_domains: *dnsdomain
+    search_domains: "%{alias('dhcp::dnsdomain')}"
 dhcp::hosts:
   M207-gs-plotter-01.cp.cl.lsst.org:
     comment: "Plotter configuration: https://jira.lsstcorp.org/browse/IHS-1600"

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -18,10 +18,6 @@
 # Grafana                       : 139.229.162.105
 # Puppet Master                 : 139.229.160.239 (Not deployed yet)
 
-chrony::servers:
-  - "ntp.shoa.cl"
-  - "1.cl.pool.ntp.org"
-  - "1.south-america.pool.ntp.org"
 
 rsyslog::client::global_config:
   workDirectory:
@@ -102,15 +98,33 @@ telegraf::quiet: false
 telegraf::hostname: ""
 telegraf::omit_hostname: false
 
-resolv_conf::nameservers:
-  - "139.229.162.22"  # dns1
-  - "139.229.162.87"  # dns2
-  - "208.67.222.222"  # These servers have high latency but avoid issues with bad reverse DNS. Change these later.
-  - "208.67.220.220"
-resolv_conf::searchpath:
+# The following keys are shared between the `dhcp` and `resolv_conf` classes:
+# - dhcp::dnsdomain
+# - dhcp::nameservers
+# - dhcp::ntpservers
+#
+# @see clusters/corecp/dhcp.yaml
+
+# resolv.conf allows for a maximum of 6 search domains with a max length of 256
+# characters.
+# @see man 5 resolv.conf
+dhcp::dnsdomain: &dnsdomains
   - "cp.lsst.org"
-  - "tuc.lsst.cloud"
-  - "lsst.cloud"
+  - "cp.cl.lsst.org"
+  - "cl.lsst.org"
   - "lsst.org"
-  - "tuc.noao.edu"
-  - "noao.edu"
+  - "lsst.local"
+# resolv.conf allows for a maximum of 3 nameservers
+# @see man 5 resolv.conf
+dhcp::nameservers: &nameservers
+  - "139.229.162.22"  # dns1.cp.lsst.org
+  - "139.229.162.87"  # dns2.cp.lsst.org
+  - "208.67.222.222"  # resolver1.opendns.com
+dhcp::ntpservers: &ntpservers
+  - "ntp.shoa.cl"
+  - "1.cl.pool.ntp.org"
+  - "1.south-america.pool.ntp.org"
+
+chrony::servers: *ntpservers
+resolv_conf::nameservers: *nameservers
+resolv_conf::searchpath: *dnsdomains

--- a/site/cp/role/k3s.yaml
+++ b/site/cp/role/k3s.yaml
@@ -1,0 +1,13 @@
+---
+# resolv.conf only allows for 6 search domains, and Kubernetes uses 3 for
+# service discovery. Additional search domains are ignored. To ensure
+# reasonable behavior we remove all domains that will not be readily used
+# within Kubernetes - if other domains are needed they must be referred to
+# by FQDN.
+#
+# @see man 5 resolv.conf
+# @see site/cp.yaml
+# @see https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues
+resolv_conf::searchpath:
+  - "cp.lsst.org"
+  - "lsst.org"


### PR DESCRIPTION
This commit uses the same data structure to set DHCP search domains and
nameservers. Previously we had separate entries for these records which caused
divergence between DHCP and resolv.conf entries, which caused some surprising
behavior. This resolves the conflict.

In addition this trims the DNS search path down to two entries for k3s nodes,
as Kubernetes adds 3 entries to the search path and excess entries are ignored.

This fixes IT-1545.