### PR TITLE
IT-1547: manage rsyslog configuration for cp site

### DIFF
--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -19,42 +19,15 @@
 # Puppet Master                 : 139.229.160.239 (Not deployed yet)
 
 
-rsyslog::client::global_config:
+# Rsyslog configuration is based on the default rsyslog.conf shipping with CentOS 7.7
+rsyslog::config::global_config:
   workDirectory:
     value: "/var/lib/rsyslog"
   maxMessageSize:
     value: "64k"
   preserveFQDN:
     value: "on"
-rsyslog::client::actions:
-  primary_log_server:
-    type: "omfwd"
-    facility: "*.*;auth,authpriv.none"
-    config:
-      Target: "gs-graylog-node-01.cp.lsst.org"
-      Port: 5514
-      Protocol: "udp"
-  all_logs_local:
-    type: "omfwd"
-    facility: "*.*;auth,authpriv.none"
-    config:
-      file: "/var/log/messages"
-  mail_logs:
-    type: "omfwd"
-    facility: "mail.*"
-    config:
-      file: "-/var/log/maillog"
-  cron_logs:
-    type: "omfwd"
-    facility: "cron.*"
-    config:
-      file: "/var/log/cron"
-  boot_logs:
-    type: "omfwd"
-    facility: "local7.*"
-    config:
-      file: "-/var/log/boot.log"
-rsyslog::client::modules:
+rsyslog::config::modules:
   imuxsock: {}
   imjournal:
     config:
@@ -64,9 +37,51 @@ rsyslog::client::modules:
       Ratelimit.Burst: 20000
   imklog: {}
   immark: {}
-  imfile:
+  imfile: {}
+rsyslog::config::actions:
+  graylog:
+    type: "omfwd"
+    facility: "*.*;auth,authpriv.none"
     config:
-      PollingInterval: 10
+      Target: "gs-graylog-node-01.cp.lsst.org"
+      Port: 5514
+      Protocol: "udp"
+  # Log anything (except mail) of level info or higher.
+  # Don't log private authentication messages!
+  messages:
+    type: "omfwd"
+    facility: "*.info;mail.none;authpriv.none;cron.none"
+    config:
+      file: "/var/log/messages"
+  # The authpriv file has restricted access.
+  secure:
+    type: "omfwd"
+    facility: "authpriv.*"
+    config:
+      file: "/var/log/secure"
+  # Everybody gets emergency messages
+  emerg:
+    type: "omusrmsg"
+    facility: "*.emerg"
+    config:
+      users: "*"
+  maillog:
+    type: "omfwd"
+    facility: "mail.*"
+    config:
+      file: "-/var/log/maillog"
+  cron:
+    type: "omfwd"
+    facility: "cron.*"
+    config:
+      file: "/var/log/cron"
+  # local7 does not appear to be used by CentOS 7, but for the sake of
+  # consistency we preserve it to match the CentOS configuration.
+  boot:
+    type: "omfwd"
+    facility: "local7.*"
+    config:
+      file: "-/var/log/boot.log"
 
 # Telegraf common configuration
 monitoring_enabled: true

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -31,7 +31,7 @@ rsyslog::client::actions:
     type: "omfwd"
     facility: "*.*;auth,authpriv.none"
     config:
-      Target: "gs-graylog-node-01.cp.cl.lsst.org"
+      Target: "gs-graylog-node-01.cp.lsst.org"
       Port: 5514
       Protocol: "udp"
   all_logs_local:

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -34,13 +34,6 @@ rsyslog::client::actions:
       Target: "gs-graylog-node-01.cp.cl.lsst.org"
       Port: 5514
       Protocol: "udp"
-  backup_log_server:
-    type: "omfwd"
-    facility: "*.*;auth,authpriv.none"
-    config:
-      Target: "gs-graylog-node-01.ls.cl.lsst.org"
-      Port: 5514
-      Protocol: "udp"
   all_logs_local:
     type: "omfwd"
     facility: "*.*;auth,authpriv.none"

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -21,7 +21,7 @@
 
 rsyslog::client::global_config:
   workDirectory:
-    value: "/var/log"
+    value: "/var/lib/rsyslog"
   maxMessageSize:
     value: "64k"
   preserveFQDN:


### PR DESCRIPTION
This pull request updates the rsyslog configuration for the Cerro Pachon site,
cleans up old configuration, and ports general configuration from the default
CentOS 7 rsyslog config file.