### PR TITLE
IT-1547: fix rsyslog local log output actions

### DIFF
--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -49,13 +49,13 @@ rsyslog::config::actions:
   # Log anything (except mail) of level info or higher.
   # Don't log private authentication messages!
   messages:
-    type: "omfwd"
+    type: "omfile"
     facility: "*.info;mail.none;authpriv.none;cron.none"
     config:
       file: "/var/log/messages"
   # The authpriv file has restricted access.
   secure:
-    type: "omfwd"
+    type: "omfile"
     facility: "authpriv.*"
     config:
       file: "/var/log/secure"
@@ -66,19 +66,19 @@ rsyslog::config::actions:
     config:
       users: "*"
   maillog:
-    type: "omfwd"
+    type: "omfile"
     facility: "mail.*"
     config:
       file: "-/var/log/maillog"
   cron:
-    type: "omfwd"
+    type: "omfile"
     facility: "cron.*"
     config:
       file: "/var/log/cron"
   # local7 does not appear to be used by CentOS 7, but for the sake of
   # consistency we preserve it to match the CentOS configuration.
   boot:
-    type: "omfwd"
+    type: "omfile"
     facility: "local7.*"
     config:
       file: "-/var/log/boot.log"


### PR DESCRIPTION
The previous pull request used an incorrect log module ("omfwd"
instead of "omfile"). This pull request fixes the error.