### PR TITLE
REVIEW: IT-1529 manage andes control network

### DIFF
--- a/cluster/andes.yaml
+++ b/cluster/andes.yaml
@@ -1,0 +1,26 @@
+---
+classes:
+  - "network"
+
+network::interfaces_hash:
+  p2p1:
+    bootproto: "none"
+    master: "bond0"
+    slave: "yes"
+    nm_controlled: "no"
+  p2p2:
+    bootproto: "none"
+    master: "bond0"
+    slave: "yes"
+    nm_controlled: "no"
+  bond0:
+    type: "Bond"
+    bootproto: "none"
+    bonding_opts: "mode=4 miimon=100"
+    bonding_master: "yes"
+    nm_controlled: "no"
+  bond0.1300:
+    vlan: "yes"
+    bootproto: "none"
+    nm_controlled: "no"
+    userctl: "no"

--- a/cluster/andes.yaml
+++ b/cluster/andes.yaml
@@ -1,4 +1,9 @@
 ---
+lookup_options:
+  network::interfaces_hash:
+    merge:
+      strategy: "deep"
+
 classes:
   - "network"
 

--- a/cluster/andes.yaml
+++ b/cluster/andes.yaml
@@ -25,6 +25,8 @@ network::interfaces_hash:
     bonding_master: "yes"
     nm_controlled: "no"
   bond0.1300:
+    ensure: "absent"
+  bond0.1301:
     vlan: "yes"
     bootproto: "none"
     nm_controlled: "no"

--- a/node/andes01.cp.lsst.org.yaml
+++ b/node/andes01.cp.lsst.org.yaml
@@ -1,5 +1,5 @@
 ---
 network::interfaces_hash:
-  bond0.1300:
+  bond0.1301:
     ipaddr: "139.229.167.2"
     netmask: "255.255.255.0"

--- a/node/andes01.cp.lsst.org.yaml
+++ b/node/andes01.cp.lsst.org.yaml
@@ -1,0 +1,5 @@
+---
+network::interfaces_hash:
+  bond0.1300:
+    ipaddr: "139.229.167.2"
+    netmask: "255.255.255.0"

--- a/node/andes02.cp.lsst.org.yaml
+++ b/node/andes02.cp.lsst.org.yaml
@@ -1,5 +1,5 @@
 ---
 network::interfaces_hash:
-  bond0.1300:
+  bond0.1301:
     ipaddr: "139.229.167.3"
     netmask: "255.255.255.0"

--- a/node/andes02.cp.lsst.org.yaml
+++ b/node/andes02.cp.lsst.org.yaml
@@ -1,0 +1,5 @@
+---
+network::interfaces_hash:
+  bond0.1300:
+    ipaddr: "139.229.167.3"
+    netmask: "255.255.255.0"

--- a/node/andes03.cp.lsst.org.yaml
+++ b/node/andes03.cp.lsst.org.yaml
@@ -1,5 +1,5 @@
 ---
 network::interfaces_hash:
-  bond0.1300:
+  bond0.1301:
     ipaddr: "139.229.167.4"
     netmask: "255.255.255.0"

--- a/node/andes03.cp.lsst.org.yaml
+++ b/node/andes03.cp.lsst.org.yaml
@@ -1,0 +1,5 @@
+---
+network::interfaces_hash:
+  bond0.1300:
+    ipaddr: "139.229.167.4"
+    netmask: "255.255.255.0"

--- a/node/andes04.cp.lsst.org.yaml
+++ b/node/andes04.cp.lsst.org.yaml
@@ -1,0 +1,7 @@
+---
+
+network::interfaces_hash:
+  p2p1:
+    hwaddr: "a0:36:9f:c7:6c:aa"
+  p2p2:
+    hwaddr: "a0:36:9f:c7:6c:a8"

--- a/node/andes04.cp.lsst.org.yaml
+++ b/node/andes04.cp.lsst.org.yaml
@@ -4,6 +4,6 @@ network::interfaces_hash:
     hwaddr: "a0:36:9f:c7:6c:aa"
   p2p2:
     hwaddr: "a0:36:9f:c7:6c:a8"
-  bond0.1300:
+  bond0.1301:
     ipaddr: "139.229.167.5"
     netmask: "255.255.255.0"

--- a/node/andes04.cp.lsst.org.yaml
+++ b/node/andes04.cp.lsst.org.yaml
@@ -1,7 +1,9 @@
 ---
-
 network::interfaces_hash:
   p2p1:
     hwaddr: "a0:36:9f:c7:6c:aa"
   p2p2:
     hwaddr: "a0:36:9f:c7:6c:a8"
+  bond0.1300:
+    ipaddr: "139.229.167.5"
+    netmask: "255.255.255.0"

--- a/node/andes05.cp.lsst.org.yaml
+++ b/node/andes05.cp.lsst.org.yaml
@@ -1,0 +1,5 @@
+---
+network::interfaces_hash:
+  bond0.1300:
+    ipaddr: "139.229.167.6"
+    netmask: "255.255.255.0"

--- a/node/andes05.cp.lsst.org.yaml
+++ b/node/andes05.cp.lsst.org.yaml
@@ -1,5 +1,5 @@
 ---
 network::interfaces_hash:
-  bond0.1300:
+  bond0.1301:
     ipaddr: "139.229.167.6"
     netmask: "255.255.255.0"

--- a/node/andes06.cp.lsst.org.yaml
+++ b/node/andes06.cp.lsst.org.yaml
@@ -1,0 +1,5 @@
+---
+network::interfaces_hash:
+  bond0.1300:
+    ipaddr: "139.229.167.7"
+    netmask: "255.255.255.0"

--- a/node/andes06.cp.lsst.org.yaml
+++ b/node/andes06.cp.lsst.org.yaml
@@ -1,5 +1,5 @@
 ---
 network::interfaces_hash:
-  bond0.1300:
+  bond0.1301:
     ipaddr: "139.229.167.7"
     netmask: "255.255.255.0"


### PR DESCRIPTION
This pull request is subject to heavy revision as we have a number of things to discuss in terms of network configuration.

One issue is that there seems to be a divergence between the network interface names that NetworkManager will assign on host provision, and the names that udev will assign when a given interface is not managed by NM. NM will assign a name like `p2p1` or `p2p2` and will track the named interface, while udev will use a name like `enp59s0f0`. This deviation may be worth discussing because I suspect that it might bite us again. This variation is why andes04 has interface definitions managing the hwaddr - without this the interface is misnamed.

Points of discussion:

1. I proposed that we use VLAN tagging on the bonded interfaces so that we can add different subnets after the fact. Is this a reasonable approach? Will this interact badly with SAL?
1. IP addresses are assigned to the `bond0.1300` interface to test network connectivity. Should we have this address assigned or only attach containers to this interface?
1. In general, do we need to have network restrictions on the control network interface to prevent excess traffic from affecting SAL traffic?

Note that this pull request targets IT-1442/rke.