### PR TITLE
IT-1595/IT-1596: manage control network routes

### DIFF
--- a/node/auxtel-control-01.cp.lsst.org.yaml
+++ b/node/auxtel-control-01.cp.lsst.org.yaml
@@ -1,0 +1,12 @@
+---
+classes:
+  "network"
+
+network::mroutes_hash:
+  p2p2:
+    # auxtel-control-01 is multihomed and has a default gateway of
+    # 139.229.162.126. These explicit routes are required to direct
+    # SAL traffic (and only SAL traffic) over the control network.
+    routes:
+      "139.229.178.0/24": "139.229.170.254"
+      "139.229.167.0/24": "139.229.170.254"

--- a/node/ts-csc-generic-01.cp.lsst.org.yaml
+++ b/node/ts-csc-generic-01.cp.lsst.org.yaml
@@ -1,0 +1,12 @@
+---
+classes:
+  "network"
+
+network::mroutes_hash:
+  p2p1:
+    # ts-csc-generic-01 is multihomed and has a default gateway of
+    # 139.229.162.126. These explicit routes are required to direct
+    # SAL traffic (and only SAL traffic) over the control network.
+    routes:
+      "139.229.178.0/24": "139.229.170.254"
+      "139.229.167.0/24": "139.229.170.254"


### PR DESCRIPTION
This commit adds node entries for the auxtel control server and original
EFD server.

This design is not ideal as both servers require the same routes, but we
have no effective mechanism for assigning network routes in Hiera to
different hosts.

That said, ts-csc-generic-01 and auxtel-control-01 use different
interfaces to connect to the control network, so it's non-trivial to use
some common configuration for this - unless we get clever with hiera.