### PR TITLE
Add NCSA support

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,7 +1,25 @@
 ---
-motd: "Server installed without custom motd\n"
-timezone::timezone: "UTC"
+# Lookup options stay at the top (sort subkeys alphabetically)
+
+lookup_options:
+  sudo::configs:
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+
+# Everything else should be sorted alphabetically
+
+baseline_cfg::networkmanager::enable: true
+baseline_cfg::networkmanager::ensure: running
+
 chrony::leapsectz: "right/UTC"
+
+motd: "Server installed without custom motd\n"
+
+rsyslog::use_upstream_repo: true
+rsyslog::feature_packages:
+  - rsyslog-relp
+
 ssh::storeconfigs_enabled: false
 ssh::server_options:
   Port: 22
@@ -55,7 +73,12 @@ easy_ipa::install_autofs: false
 easy_ipa::install_sssdtools: false
 easy_ipa::install_kstart: false
 easy_ipa::configure_sshd: false
+
 ssh::client_options:
   GlobalKnownHostsFile: "/var/lib/sss/pubconf/known_hosts"
   PubkeyAuthentication: "yes"
   ProxyCommand: "/usr/bin/sss_ssh_knownhostsproxy -p %p %h"
+
+sudo::content: system_authnz/sudoers.erb
+
+timezone::timezone: UTC

--- a/role/default.yaml
+++ b/role/default.yaml
@@ -1,0 +1,4 @@
+---
+classes:
+  - profile::baseline_cfg
+  - profile::system_authnz

--- a/site/npcf.yaml
+++ b/site/npcf.yaml
@@ -1,0 +1,456 @@
+---
+pakrat_client::default_snapshot: '2019-09-16-1568669101'
+pakrat_client::default_yumserver_url: http://lsst-repos01.ncsa.illinois.edu
+pakrat_client::repos:
+  base:
+    descr: CentOS-$releasever - Base
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  centosplus:
+    descr: CentOS-$releasever - Plus
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  epel:
+    descr: Extra Packages for Enterprise Linux 7 - $basearch
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  extras:
+    descr: CentOS-$releasever - Extras
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  puppet5:
+    descr: Puppet 5 Repository el 7 - x86_64
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
+  puppetlabs-pc1:
+    ensure: absent
+  puppetlabs-pc1-source:
+    ensure: absent
+  updates:
+    descr: CentOS-$releasever - Updates
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  # Ad-hoc security_updates repo (when we don't want to move all snapshots ahead)
+  security_updates:
+    # snapshot will almost certainly differ than our current CentOS snapshot
+    snapshot: '2019-01-15-1547581639'
+    # if it is present, then we want it enabled
+    enabled: 1
+    # set to absent when we do not need to use this repo; set to present when we need it
+    ensure: absent
+    # set gpgcheck to 0 if we have built our own RPMs
+    gpgcheck: 0
+    # if we use GPG key checking, it's probably because we have only CentOS-built RPMs in the repo
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+rsyslog::client::log_local: true
+rsyslog::client::remote_servers: false
+rsyslog::client::remote_type: 'tcp'
+rsyslog::client::preserve_fqdn: true
+
+sssd::debug_level: 0
+
+sssd::domains:
+  ncsa.illinois.edu:
+    access_provider: simple
+    auth_provider: krb5
+    cache_credentials: false
+    chpass_provider: krb5
+    debug_level: 0
+    enumerate: false
+    id_provider: ldap
+    krb5_auth_timeout: 3
+    krb5_lifetime: 25h
+    # TODO MAKE THIS A HIERA INTERPOLATION LOOKUP
+    krb5_realm: NCSA.EDU
+    krb5_renew_interval: 3600
+    krb5_renewable_lifetime: 7d
+    krb5_use_kdcinfo: false
+    krb5_validate: true
+    ldap_backup_uri:
+      - ldaps://ldap1.ncsa.illinois.edu
+      - ldaps://ldap2.ncsa.illinois.edu
+      - ldaps://ldap.ncsa.illinois.edu
+    ldap_group_member: uniqueMember
+    ldap_group_search_base: dc=ncsa,dc=illinois,dc=edu?subtree?(&(objectclass=groupOfUniqueNames)(|(cn=lsst_*)(cn=all_lsst)(cn=all_disabled_usr)(cn=grp_202)))
+    ldap_schema: rfc2307bis
+    ldap_search_base: dc=ncsa,dc=illinois,dc=edu
+    # TODO MAKE THIS A HIERA INTERPOLATION LOOKUP
+    ldap_tls_cacert: /etc/pki/ca-trust/source/anchors/incommon-ca.pem
+    ldap_tls_reqcert: demand
+    ldap_uri:
+      - ldaps://ldap-lsst-ncsa1.ncsa.illinois.edu
+      - ldaps://ldap-lsst-ncsa2.ncsa.illinois.edu
+    ldap_user_search_base: dc=ncsa,dc=illinois,dc=edu?subtree?(&(objectclass=inetOrgPerson)(memberOf=cn=all_lsst,ou=groups,dc=ncsa,dc=illinois,dc=edu))
+    simple_allow_groups:
+      - lsst_sysadmin
+      - from_nts_yaml
+    simple_deny_groups:
+      - all_disabled_usr
+      - lsst_disabled
+
+sssd::services:
+  nss:
+    override_homedir: /home/%u
+    shell_fallback: /bin/bash
+    filter_groups:
+      - adm
+      - apache
+      - asmadmin
+      - asmdba
+      - asmoper
+      - audio
+      - avahi
+      - avahi-autoipd
+      - backupdba
+      - bin
+      - cdrom
+      - cgred
+      - chronograf
+      - chrony
+      - condor
+      - conserver
+      - daemon
+      - dba
+      - dbus
+      - dgdba
+      - dhcpd
+      - dialout
+      - dip
+      - disk
+      - docker
+      - elasticsearch
+      - floppy
+      - ftp
+      - games
+      - geoclue
+      - git
+      - gitlab-prometheus
+      - gitlab-psql
+      - gitlab-redis
+      - gitlab-www
+      - grafana
+      - graylog
+      - graylog-web
+      - hsqldb
+      - influxdb
+      - input
+      - kmdba
+      - kmem
+      - ldap
+      - levelone
+      - lock
+      - lp
+      - mail
+      - man
+      - mem
+      - mongod
+      - munge
+      - myproxy
+      - myproxyoauth
+      - mysql
+      - nagios
+      - named
+      - nfsnobody
+      - nobody
+      - nrpe
+      - nscd
+      - ntp
+      - oinstall
+      - oper
+      - oprofile
+      - pdagent
+      - polkitd
+      - postdrop
+      - postfix
+      - postgres
+      - puppet
+      - puppetdb
+      - qserv
+      - qualys
+      - rabbitmq
+      - racdba
+      - redis
+      - root
+      - rpc
+      - rpcuser
+      - saslauth
+      - screen
+      - sfcb
+      - simpleca
+      - slocate
+      - slurm
+      - sshd
+      - ssh_keys
+      - sssd
+      - stapdev
+      - stapsys
+      - stapusr
+      - suiadmin
+      - SupportAssistAdmins
+      - SupportAssistUsers
+      - sys
+      - systemd-bus-proxy
+      - systemd-journal
+      - systemd-network
+      - tape
+      - tcpdump
+      - telegraf
+      - tss
+      - tty
+      - unbound
+      - users
+      - utempter
+      - utmp
+      - video
+      - wheel
+    filter_users:
+      - activemq
+      - adm
+      - apache
+      - avahi
+      - avahi-autoipd
+      - bin
+      - chronograf
+      - chrony
+      - condor
+      - daemon
+      - dbus
+      - docker
+      - elasticsearch
+      - ftp
+      - games
+      - geoclue
+      - grafana
+      - graylog
+      - graylog-web
+      - grid
+      - halt
+      - hsqldb
+      - influxdb
+      - ldap
+      - lp
+      - mail
+      - mongod
+      - munge
+      - myproxy
+      - myproxyoauth
+      - mysql
+      - nagios
+      - nfsnobody
+      - nobody
+      - nrpe
+      - nscd
+      - nslcd
+      - ntp
+      - operator
+      - oprofile
+      - oracle
+      - pdagent
+      - polkitd
+      - postfix
+      - rabbitmq
+      - redis
+      - rsbackup
+      - qserv
+      - qualys
+      - root
+      - rpc
+      - rpcuser
+      - saslauth
+      - shutdown
+      - simpleca
+      - slurm
+      - sshd
+      - sssd
+      - suiadmin
+      - sync
+      - systemd-bus-proxy
+      - systemd-network
+      - tcpdump
+      - telegraf
+      - tomcat
+      - tss
+      - unbound
+      - wireshark
+  pam: {}
+
+sudo::configs:
+  # Defaults should probably move to common.yaml
+  defaults:
+    priority: 0
+    content:
+      - 'Defaults   !visiblepw'
+      - 'Defaults  always_set_home'
+      - 'Defaults  env_reset'
+      - 'Defaults  env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS"'
+      - 'Defaults  env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"'
+      - 'Defaults  env_keep += "LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES"'
+      - 'Defaults  env_keep += "LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE"'
+      - 'Defaults  env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY"'
+      - 'Defaults  match_group_by_gid'
+      - 'Defaults  secure_path = /sbin:/bin:/usr/sbin:/usr/bin'
+      - 'root ALL=(ALL)   ALL'
+  common_disabled_users:
+    priority: 1
+    content:
+      - '#deny former NCSA users'
+      - '%all_disabled_usr ALL=(ALL) !ALL'
+      - '#deny users in lsst_disabled LDAP group'
+      - '%lsst_disabled ALL=(ALL) !ALL'
+  common_lsst_admins:
+    priority: 10
+    content:
+      - '%lsst_sysadm ALL=(ALL) NOPASSWD: ALL'
+
+system_authnz::access::access_allow:
+  'Allow group lsst_sysadm from ALL':
+    group: lsst_sysadm
+    origin: ALL
+system_authnz::access::access_deny_before:
+  'Deny group lsst_disabled from ALL':
+    group: lsst_disabled
+    origin: ALL
+  'Deny group all_disabled_usr from ALL':
+    group: all_disabled_usr
+    origin: ALL
+
+system_authnz::kerberos::cfg_file_settings:
+  /etc/krb5.conf.d/domain_realm.conf: |
+    # This file is managed by Puppet.
+    [domain_realm]
+    .ncsa.illinois.edu = NCSA.EDU
+    .ncsa.uiuc.edu = NCSA.EDU
+    .ncsa.edu = NCSA.EDU
+    .cosmology.illinois.edu = NCSA.EDU
+  /etc/krb5.conf.d/kdc.conf: |
+    # This file is managed by Puppet.
+    [kdc]
+    profile = /etc/kdc.conf
+    afs_salt = NCSA.UIUC.EDU
+  /etc/krb5.conf.d/libdefaults.conf: |
+    # This file is managed by Puppet.
+    [libdefaults]
+    default_ccache_name = KEYRING:persistent:%{literal('%')}{uid}
+    default_realm = NCSA.EDU
+    forwardable = true
+    noaddresses = false
+  /etc/krb5.conf.d/realms.conf: |
+    # This file is managed by Puppet.
+    [realms]
+    NCSA.EDU = {
+    kdc = krb-lsst-ncsa1.ncsa.illinois.edu:88
+    kdc = krb-lsst-ncsa2.ncsa.illinois.edu:88
+    kdc = straw.ncsa.illinois.edu:88
+    kdc = wood.ncsa.illinois.edu:88
+    kdc = kerberos.ncsa.illinois.edu:88
+    admin_server = kadmin.ncsa.illinois.edu:749
+    default_domain = ncsa.illinois.edu
+    }
+system_authnz::kerberos::createhostuser: lsst
+system_authnz::kerberos::krb5_domain: NCSA.EDU
+
+system_authnz::sssd::enablemkhomedir: true
+
+unbound::log_file: /var/log/unbound.log
+unbound::local_domain: ncsa.illinois.edu
+unbound::search_domains:
+  - lsst.ncsa.edu
+  - ncsa.illinois.edu
+unbound::forward_servers:
+  - server: '141.142.2.2'
+    comment: NCSA primary
+  - server: '141.142.230.144'
+    comment: NCSA secondary
+unbound::backup_dns_servers:
+  - server: '141.142.2.2'
+    comment: NCSA primary
+  - server: '141.142.230.144'
+    comment: NCSA secondary
+unbound::reverse_overrides:
+  - [192.10.in-addr.arpa., 130.126.2.131]
+  - [193.10.in-addr.arpa., 130.126.2.131]
+  - [194.10.in-addr.arpa., 130.126.2.131]
+  - [195.10.in-addr.arpa., 130.126.2.131]
+  - [196.10.in-addr.arpa., 130.126.2.131]
+  - [197.10.in-addr.arpa., 130.126.2.131]
+  - [198.10.in-addr.arpa., 130.126.2.131]
+  - [199.10.in-addr.arpa., 130.126.2.131]
+  - [200.10.in-addr.arpa., 130.126.2.131]
+  - [201.10.in-addr.arpa., 130.126.2.131]
+  - [202.10.in-addr.arpa., 130.126.2.131]
+  - [203.10.in-addr.arpa., 130.126.2.131]
+  - [204.10.in-addr.arpa., 130.126.2.131]
+  - [205.10.in-addr.arpa., 130.126.2.131]
+  - [206.10.in-addr.arpa., 130.126.2.131]
+  - [207.10.in-addr.arpa., 130.126.2.131]
+  - [208.10.in-addr.arpa., 130.126.2.131]
+  - [209.10.in-addr.arpa., 130.126.2.131]
+  - [210.10.in-addr.arpa., 130.126.2.131]
+  - [211.10.in-addr.arpa., 130.126.2.131]
+  - [212.10.in-addr.arpa., 130.126.2.131]
+  - [213.10.in-addr.arpa., 130.126.2.131]
+  - [214.10.in-addr.arpa., 130.126.2.131]
+  - [215.10.in-addr.arpa., 130.126.2.131]
+  - [216.10.in-addr.arpa., 130.126.2.131]
+  - [217.10.in-addr.arpa., 130.126.2.131]
+  - [218.10.in-addr.arpa., 130.126.2.131]
+  - [219.10.in-addr.arpa., 130.126.2.131]
+  - [220.10.in-addr.arpa., 130.126.2.131]
+  - [221.10.in-addr.arpa., 130.126.2.131]
+  - [222.10.in-addr.arpa., 130.126.2.131]
+  - [223.10.in-addr.arpa., 130.126.2.131]
+  - [224.10.in-addr.arpa., 130.126.2.131]
+  - [225.10.in-addr.arpa., 130.126.2.131]
+  - [226.10.in-addr.arpa., 130.126.2.131]
+  - [227.10.in-addr.arpa., 130.126.2.131]
+  - [228.10.in-addr.arpa., 130.126.2.131]
+  - [229.10.in-addr.arpa., 130.126.2.131]
+  - [230.10.in-addr.arpa., 130.126.2.131]
+  - [231.10.in-addr.arpa., 130.126.2.131]
+  - [232.10.in-addr.arpa., 130.126.2.131]
+  - [233.10.in-addr.arpa., 130.126.2.131]
+  - [234.10.in-addr.arpa., 130.126.2.131]
+  - [235.10.in-addr.arpa., 130.126.2.131]
+  - [236.10.in-addr.arpa., 130.126.2.131]
+  - [237.10.in-addr.arpa., 130.126.2.131]
+  - [238.10.in-addr.arpa., 130.126.2.131]
+  - [239.10.in-addr.arpa., 130.126.2.131]
+  - [240.10.in-addr.arpa., 130.126.2.131]
+  - [241.10.in-addr.arpa., 130.126.2.131]
+  - [242.10.in-addr.arpa., 130.126.2.131]
+  - [243.10.in-addr.arpa., 130.126.2.131]
+  - [244.10.in-addr.arpa., 130.126.2.131]
+  - [245.10.in-addr.arpa., 130.126.2.131]
+  - [246.10.in-addr.arpa., 130.126.2.131]
+  - [247.10.in-addr.arpa., 130.126.2.131]
+  - [248.10.in-addr.arpa., 130.126.2.131]
+  - [249.10.in-addr.arpa., 130.126.2.131]
+  - [250.10.in-addr.arpa., 130.126.2.131]
+  - [251.10.in-addr.arpa., 130.126.2.131]
+  - [252.10.in-addr.arpa., 130.126.2.131]
+  - [253.10.in-addr.arpa., 130.126.2.131]
+  - [254.10.in-addr.arpa., 130.126.2.131]
+  - [255.10.in-addr.arpa., 130.126.2.131]
+  - [16.172.in-addr.arpa., 130.126.2.131]
+  - [17.172.in-addr.arpa., 130.126.2.131]
+  - [18.172.in-addr.arpa., 130.126.2.131]
+  - [19.172.in-addr.arpa., 130.126.2.131]
+  - [20.172.in-addr.arpa., 130.126.2.131]
+  - [21.172.in-addr.arpa., 130.126.2.131]
+  - [22.172.in-addr.arpa., 130.126.2.131]
+  - [23.172.in-addr.arpa., 130.126.2.131]
+  - [10.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [24.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [25.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [26.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [27.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [28.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [29.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [30.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [31.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]

--- a/site/nts.yaml
+++ b/site/nts.yaml
@@ -1,0 +1,535 @@
+---
+pakrat_client::default_snapshot: '2019-12-03-1575411902'
+pakrat_client::default_yumserver_url: http://lsst-repos01.ncsa.illinois.edu
+pakrat_client::repos:
+  base:
+    descr: CentOS-$releasever - Base
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  centosplus:
+    descr: CentOS-$releasever - Plus
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  epel:
+    descr: Extra Packages for Enterprise Linux 7 - $basearch
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  extras:
+    descr: CentOS-$releasever - Extras
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  puppet5:
+    descr: Puppet 5 Repository el 7 - x86_64
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
+  puppetlabs-pc1:
+    ensure: absent
+  puppetlabs-pc1-source:
+    ensure: absent
+  updates:
+    descr: CentOS-$releasever - Updates
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  # Ad-hoc security_updates repo (when we don't want to move all snapshots ahead)
+  security_updates:
+    # snapshot will almost certainly differ than our current CentOS snapshot
+    snapshot: '2019-01-15-1547581639'
+    # if it is present, then we want it enabled
+    enabled: 1
+    # set to absent when we do not need to use this repo; set to present when we need it
+    ensure: absent
+    # set gpgcheck to 0 if we have built our own RPMs
+    gpgcheck: 0
+    # if we use GPG key checking, it's probably because we have only CentOS-built RPMs in the repo
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+rsyslog::client::actions:
+  ncsa_security_loghost:
+    type: omrelp
+    facility: "*.*;auth,authpriv.none"
+    config:
+      Target: syslog.security.ncsa.illinois.edu
+      Port: 1514
+      queue.FileName: syslog-security-buffer
+      queue.SaveOnShutdown: "on"
+      queue.Type: LinkedList
+      queue.size: 100000
+      queue.maxdiskspace: 10000000000
+      queue.syncqueuefiles: "on"
+      Action.ResumeInterval: 30
+      Action.ResumeRetryCount: -1
+      Timeout: 5
+  ncsa_npcf_loghost:
+    type: omrelp
+    facility: "*.*;auth,authpriv.none"
+    config:
+      Target: localhost
+      Port: 5514
+      queue.FileName: npcf-loghost-buffer
+      queue.SaveOnShutdown: "on"
+      queue.Type: LinkedList
+      queue.size: 100000
+      queue.maxdiskspace: 10000000000
+      queue.syncqueuefiles: "on"
+      Action.ResumeInterval: 30
+      Action.ResumeRetryCount: -1
+      Timeout: 5
+  all_logs_local:
+    type: omfile
+    facility: "*.info;mail.none;authpriv.none;cron.none"
+    config:
+      file: /var/log/messages
+  auth_logs:
+    type: omfile
+    facility: auth,authpriv.*
+    config:
+      file: /var/log/secure
+  mail_logs:
+    type: omfile
+    facility: mail.*
+    config:
+      file: "-/var/log/maillog"
+  cron_logs:
+    type: omfile
+    facility: cron.*
+    config:
+      file: /var/log/cron
+  emergency_msgs:
+    type: omusrmsg
+    facility: "*.emerg"
+    config:
+      users: '*'
+  boot_logs:
+    type: omfile
+    facility: local7.*
+    config:
+      file: "-/var/log/boot.log"
+rsyslog::client::modules:
+  imuxsock: {}
+  imjournal:
+    config:
+      StateFile: imjournal.state
+      IgnorePreviousMessages: "off"
+      Ratelimit.Interval: 600
+      Ratelimit.Burst: 20000
+  imklog: {}
+  immark: {}
+  imfile:
+    config:
+      PollingInterval: 10
+  omrelp: {}
+rsyslog::client::global_config:
+  workDirectory:
+    value: /var/log
+  maxMessageSize:
+    value: "64k"
+  preserveFQDN:
+    value: "on"
+
+
+sssd::debug_level: 0
+
+sssd::domains:
+  ncsa.illinois.edu:
+    access_provider: simple
+    auth_provider: krb5
+    cache_credentials: false
+    chpass_provider: krb5
+    debug_level: 0
+    enumerate: false
+    id_provider: ldap
+    krb5_auth_timeout: 3
+    krb5_lifetime: 25h
+    # TODO MAKE THIS A HIERA INTERPOLATION LOOKUP
+    krb5_realm: NCSA.EDU
+    krb5_renew_interval: 3600
+    krb5_renewable_lifetime: 7d
+    krb5_use_kdcinfo: false
+    krb5_validate: true
+    ldap_backup_uri:
+      - ldaps://ldap1.ncsa.illinois.edu
+      - ldaps://ldap2.ncsa.illinois.edu
+      - ldaps://ldap.ncsa.illinois.edu
+    ldap_group_member: uniqueMember
+    ldap_group_search_base: dc=ncsa,dc=illinois,dc=edu?subtree?(&(objectclass=groupOfUniqueNames)(|(cn=lsst_*)(cn=all_lsst)(cn=all_disabled_usr)(cn=grp_202)))
+    ldap_schema: rfc2307bis
+    ldap_search_base: dc=ncsa,dc=illinois,dc=edu
+    # TODO MAKE THIS A HIERA INTERPOLATION LOOKUP
+    ldap_tls_cacert: /etc/pki/ca-trust/source/anchors/incommon-ca.pem
+    ldap_tls_reqcert: demand
+    ldap_uri:
+      - ldaps://ldap-lsst-ncsa1.ncsa.illinois.edu
+      - ldaps://ldap-lsst-ncsa2.ncsa.illinois.edu
+    ldap_user_search_base: dc=ncsa,dc=illinois,dc=edu?subtree?(&(objectclass=inetOrgPerson)(memberOf=cn=all_lsst,ou=groups,dc=ncsa,dc=illinois,dc=edu))
+    simple_allow_groups:
+      - lsst_sysadmin
+      - from_nts_yaml
+    simple_deny_groups:
+      - all_disabled_usr
+      - lsst_disabled
+
+sssd::services:
+  nss:
+    override_homedir: /home/%u
+    shell_fallback: /bin/bash
+    filter_groups:
+      - adm
+      - apache
+      - asmadmin
+      - asmdba
+      - asmoper
+      - audio
+      - avahi
+      - avahi-autoipd
+      - backupdba
+      - bin
+      - cdrom
+      - cgred
+      - chronograf
+      - chrony
+      - condor
+      - conserver
+      - daemon
+      - dba
+      - dbus
+      - dgdba
+      - dhcpd
+      - dialout
+      - dip
+      - disk
+      - docker
+      - elasticsearch
+      - floppy
+      - ftp
+      - games
+      - geoclue
+      - git
+      - gitlab-prometheus
+      - gitlab-psql
+      - gitlab-redis
+      - gitlab-www
+      - grafana
+      - graylog
+      - graylog-web
+      - hsqldb
+      - influxdb
+      - input
+      - kmdba
+      - kmem
+      - ldap
+      - levelone
+      - lock
+      - lp
+      - mail
+      - man
+      - mem
+      - mongod
+      - munge
+      - myproxy
+      - myproxyoauth
+      - mysql
+      - nagios
+      - named
+      - nfsnobody
+      - nobody
+      - nrpe
+      - nscd
+      - ntp
+      - oinstall
+      - oper
+      - oprofile
+      - pdagent
+      - polkitd
+      - postdrop
+      - postfix
+      - postgres
+      - puppet
+      - puppetdb
+      - qserv
+      - qualys
+      - rabbitmq
+      - racdba
+      - redis
+      - root
+      - rpc
+      - rpcuser
+      - saslauth
+      - screen
+      - sfcb
+      - simpleca
+      - slocate
+      - slurm
+      - sshd
+      - ssh_keys
+      - sssd
+      - stapdev
+      - stapsys
+      - stapusr
+      - suiadmin
+      - SupportAssistAdmins
+      - SupportAssistUsers
+      - sys
+      - systemd-bus-proxy
+      - systemd-journal
+      - systemd-network
+      - tape
+      - tcpdump
+      - telegraf
+      - tss
+      - tty
+      - unbound
+      - users
+      - utempter
+      - utmp
+      - video
+      - wheel
+    filter_users:
+      - activemq
+      - adm
+      - apache
+      - avahi
+      - avahi-autoipd
+      - bin
+      - chronograf
+      - chrony
+      - condor
+      - daemon
+      - dbus
+      - docker
+      - elasticsearch
+      - ftp
+      - games
+      - geoclue
+      - grafana
+      - graylog
+      - graylog-web
+      - grid
+      - halt
+      - hsqldb
+      - influxdb
+      - ldap
+      - lp
+      - mail
+      - mongod
+      - munge
+      - myproxy
+      - myproxyoauth
+      - mysql
+      - nagios
+      - nfsnobody
+      - nobody
+      - nrpe
+      - nscd
+      - nslcd
+      - ntp
+      - operator
+      - oprofile
+      - oracle
+      - pdagent
+      - polkitd
+      - postfix
+      - rabbitmq
+      - redis
+      - rsbackup
+      - qserv
+      - qualys
+      - root
+      - rpc
+      - rpcuser
+      - saslauth
+      - shutdown
+      - simpleca
+      - slurm
+      - sshd
+      - sssd
+      - suiadmin
+      - sync
+      - systemd-bus-proxy
+      - systemd-network
+      - tcpdump
+      - telegraf
+      - tomcat
+      - tss
+      - unbound
+      - wireshark
+  pam: {}
+
+sudo::configs:
+  # Defaults should probably move to common.yaml
+  defaults:
+    priority: 0
+    content:
+      - 'Defaults   !visiblepw'
+      - 'Defaults  always_set_home'
+      - 'Defaults  env_reset'
+      - 'Defaults  env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS"'
+      - 'Defaults  env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"'
+      - 'Defaults  env_keep += "LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES"'
+      - 'Defaults  env_keep += "LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE"'
+      - 'Defaults  env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY"'
+      - 'Defaults  match_group_by_gid'
+      - 'Defaults  secure_path = /sbin:/bin:/usr/sbin:/usr/bin'
+      - 'root ALL=(ALL)   ALL'
+  common_disabled_users:
+    priority: 1
+    content:
+      - '#deny former NCSA users'
+      - '%all_disabled_usr ALL=(ALL) !ALL'
+      - '#deny users in lsst_disabled LDAP group'
+      - '%lsst_disabled ALL=(ALL) !ALL'
+  common_lsst_admins:
+    priority: 10
+    content:
+      - '%lsst_sysadm ALL=(ALL) NOPASSWD: ALL'
+
+system_authnz::access::access_allow:
+  'Allow group lsst_sysadm from ALL':
+    group: lsst_sysadm
+    origin: ALL
+system_authnz::access::access_deny_before:
+  'Deny group lsst_disabled from ALL':
+    group: lsst_disabled
+    origin: ALL
+  'Deny group all_disabled_usr from ALL':
+    group: all_disabled_usr
+    origin: ALL
+
+system_authnz::kerberos::cfg_file_settings:
+  /etc/krb5.conf.d/domain_realm.conf: |
+    # This file is managed by Puppet.
+    [domain_realm]
+    .ncsa.illinois.edu = NCSA.EDU
+    .ncsa.uiuc.edu = NCSA.EDU
+    .ncsa.edu = NCSA.EDU
+    .cosmology.illinois.edu = NCSA.EDU
+  /etc/krb5.conf.d/kdc.conf: |
+    # This file is managed by Puppet.
+    [kdc]
+    profile = /etc/kdc.conf
+    afs_salt = NCSA.UIUC.EDU
+  /etc/krb5.conf.d/libdefaults.conf: |
+    # This file is managed by Puppet.
+    [libdefaults]
+    default_ccache_name = KEYRING:persistent:%{literal('%')}{uid}
+    default_realm = NCSA.EDU
+    forwardable = true
+    noaddresses = false
+  /etc/krb5.conf.d/realms.conf: |
+    # This file is managed by Puppet.
+    [realms]
+    NCSA.EDU = {
+    kdc = krb-lsst-ncsa1.ncsa.illinois.edu:88
+    kdc = krb-lsst-ncsa2.ncsa.illinois.edu:88
+    kdc = straw.ncsa.illinois.edu:88
+    kdc = wood.ncsa.illinois.edu:88
+    kdc = kerberos.ncsa.illinois.edu:88
+    admin_server = kadmin.ncsa.illinois.edu:749
+    default_domain = ncsa.illinois.edu
+    }
+system_authnz::kerberos::createhostuser: lsst
+system_authnz::kerberos::krb5_domain: NCSA.EDU
+
+system_authnz::sssd::enablemkhomedir: true
+
+unbound::log_file: /var/log/unbound.log
+unbound::local_domain: ncsa.illinois.edu
+unbound::search_domains:
+  - lsst.ncsa.edu
+  - ncsa.illinois.edu
+unbound::forward_servers:
+  - server: '141.142.2.2'
+    comment: NCSA primary
+  - server: '141.142.230.144'
+    comment: NCSA secondary
+unbound::backup_dns_servers:
+  - server: '141.142.2.2'
+    comment: NCSA primary
+  - server: '141.142.230.144' # '130.126.2.131'
+    comment: NCSA secondary # 'campus DNS'
+unbound::reverse_overrides:
+  - [192.10.in-addr.arpa., 130.126.2.131]
+  - [193.10.in-addr.arpa., 130.126.2.131]
+  - [194.10.in-addr.arpa., 130.126.2.131]
+  - [195.10.in-addr.arpa., 130.126.2.131]
+  - [196.10.in-addr.arpa., 130.126.2.131]
+  - [197.10.in-addr.arpa., 130.126.2.131]
+  - [198.10.in-addr.arpa., 130.126.2.131]
+  - [199.10.in-addr.arpa., 130.126.2.131]
+  - [200.10.in-addr.arpa., 130.126.2.131]
+  - [201.10.in-addr.arpa., 130.126.2.131]
+  - [202.10.in-addr.arpa., 130.126.2.131]
+  - [203.10.in-addr.arpa., 130.126.2.131]
+  - [204.10.in-addr.arpa., 130.126.2.131]
+  - [205.10.in-addr.arpa., 130.126.2.131]
+  - [206.10.in-addr.arpa., 130.126.2.131]
+  - [207.10.in-addr.arpa., 130.126.2.131]
+  - [208.10.in-addr.arpa., 130.126.2.131]
+  - [209.10.in-addr.arpa., 130.126.2.131]
+  - [210.10.in-addr.arpa., 130.126.2.131]
+  - [211.10.in-addr.arpa., 130.126.2.131]
+  - [212.10.in-addr.arpa., 130.126.2.131]
+  - [213.10.in-addr.arpa., 130.126.2.131]
+  - [214.10.in-addr.arpa., 130.126.2.131]
+  - [215.10.in-addr.arpa., 130.126.2.131]
+  - [216.10.in-addr.arpa., 130.126.2.131]
+  - [217.10.in-addr.arpa., 130.126.2.131]
+  - [218.10.in-addr.arpa., 130.126.2.131]
+  - [219.10.in-addr.arpa., 130.126.2.131]
+  - [220.10.in-addr.arpa., 130.126.2.131]
+  - [221.10.in-addr.arpa., 130.126.2.131]
+  - [222.10.in-addr.arpa., 130.126.2.131]
+  - [223.10.in-addr.arpa., 130.126.2.131]
+  - [224.10.in-addr.arpa., 130.126.2.131]
+  - [225.10.in-addr.arpa., 130.126.2.131]
+  - [226.10.in-addr.arpa., 130.126.2.131]
+  - [227.10.in-addr.arpa., 130.126.2.131]
+  - [228.10.in-addr.arpa., 130.126.2.131]
+  - [229.10.in-addr.arpa., 130.126.2.131]
+  - [230.10.in-addr.arpa., 130.126.2.131]
+  - [231.10.in-addr.arpa., 130.126.2.131]
+  - [232.10.in-addr.arpa., 130.126.2.131]
+  - [233.10.in-addr.arpa., 130.126.2.131]
+  - [234.10.in-addr.arpa., 130.126.2.131]
+  - [235.10.in-addr.arpa., 130.126.2.131]
+  - [236.10.in-addr.arpa., 130.126.2.131]
+  - [237.10.in-addr.arpa., 130.126.2.131]
+  - [238.10.in-addr.arpa., 130.126.2.131]
+  - [239.10.in-addr.arpa., 130.126.2.131]
+  - [240.10.in-addr.arpa., 130.126.2.131]
+  - [241.10.in-addr.arpa., 130.126.2.131]
+  - [242.10.in-addr.arpa., 130.126.2.131]
+  - [243.10.in-addr.arpa., 130.126.2.131]
+  - [244.10.in-addr.arpa., 130.126.2.131]
+  - [245.10.in-addr.arpa., 130.126.2.131]
+  - [246.10.in-addr.arpa., 130.126.2.131]
+  - [247.10.in-addr.arpa., 130.126.2.131]
+  - [248.10.in-addr.arpa., 130.126.2.131]
+  - [249.10.in-addr.arpa., 130.126.2.131]
+  - [250.10.in-addr.arpa., 130.126.2.131]
+  - [251.10.in-addr.arpa., 130.126.2.131]
+  - [252.10.in-addr.arpa., 130.126.2.131]
+  - [253.10.in-addr.arpa., 130.126.2.131]
+  - [254.10.in-addr.arpa., 130.126.2.131]
+  - [255.10.in-addr.arpa., 130.126.2.131]
+  - [16.172.in-addr.arpa., 130.126.2.131]
+  - [17.172.in-addr.arpa., 130.126.2.131]
+  - [18.172.in-addr.arpa., 130.126.2.131]
+  - [19.172.in-addr.arpa., 130.126.2.131]
+  - [20.172.in-addr.arpa., 130.126.2.131]
+  - [21.172.in-addr.arpa., 130.126.2.131]
+  - [22.172.in-addr.arpa., 130.126.2.131]
+  - [23.172.in-addr.arpa., 130.126.2.131]
+  - [10.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [24.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [25.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [26.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [27.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [28.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [29.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [30.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]
+  - [31.172.in-addr.arpa., 141.142.2.2, 141.142.230.144]

--- a/site/nts.yaml
+++ b/site/nts.yaml
@@ -449,8 +449,8 @@ unbound::forward_servers:
 unbound::backup_dns_servers:
   - server: '141.142.2.2'
     comment: NCSA primary
-  - server: '141.142.230.144' # '130.126.2.131'
-    comment: NCSA secondary # 'campus DNS'
+  - server: '141.142.230.144'
+    comment: NCSA secondary
 unbound::reverse_overrides:
   - [192.10.in-addr.arpa., 130.126.2.131]
   - [193.10.in-addr.arpa., 130.126.2.131]


### PR DESCRIPTION
Add npcf and nts files in site/

Add role/default

Remove "wheel" from default sudoers

Use custom template for sudo::content

Remove ntp

Common.yaml
-----------
Add lookup_options for sudo::configs
Add settings for baseline_cfg::networkmanager
Add chronyd default servers
Move timezone to end (to sort alphabetically)
Migrate to aboe/chrony (replaces beergeek/chronyd)
...Remove default servers list from common.yaml
...Module defaults are sufficient

Migrate to puppet/rsyslog (replaces saz/rsyslog)

Add rsyslog-relp

Update pakrat::client snapshot to 2019-12-03-1575411902

Fix typos in common.yaml

Enable rsyslog upstream repo
...Needed for a working relp package
...Built in one doesn't work

Test sending logs to multiple remote servers