### PR TITLE
maint: fixup r10k postrun hiera config

### DIFF
--- a/role/foreman.yaml
+++ b/role/foreman.yaml
@@ -24,7 +24,7 @@ r10k::sources:
   lsst_hiera_public:
     remote: "https://github.com/lsst-it/lsst-puppet-hiera.git"
     basedir: "/etc/puppetlabs/code/hieradata/public"
-  postrun: ['/bin/hammer', 'proxy', 'import-classes', '--id=1']
+r10k::postrun: ['/bin/hammer', 'proxy', 'import-classes', '--id=1']
 r10k::webhook::config::use_mcollective: false
 r10k::webhook::config::enable_ssl: false
 r10k::webhook::config::protected: false


### PR DESCRIPTION
We accidentally set the `postrun` command as an r10k source, which
produced an invalid config. This commit corrects the typo.