### PR TITLE
IT-1685: remove local provisioning accounts

### DIFF
--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -169,3 +169,11 @@ accounts::user_list:
   athebo_b:  # backup access in case LDAP fails
     sshkeys:
       - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE8XVjITG6l2q37rDrL037aB2vDr0HsdXAl1ffmhj9TK adrien@faraday"
+  lssttech:
+    ensure: "absent"
+    managehome: true
+    purge_user_home: true
+  sysadmin:
+    ensure: "absent"
+    managehome: true
+    purge_user_home: true


### PR DESCRIPTION
Shared provisioning accounts and party accounts were used for systems
administration tasks before IPA was rolled out. Now that IPA is the first
system that we install on Puppet managed hosts and is universally deployed, we
do not need these local accounts.

This pull request removes the two known local accounts and wipes the home
directories. This approach means that once a host is bootstrapped with Puppet
and IPA we strip out the provisioning accounts.

In cause of LDAP failure we have some backup accounts (also managed by Puppet)
to get in. Let's use per-user accounts for that work rather than shared
accounts.