### PR TITLE
IT-1686: add auxtel NFS exports, mounts

### DIFF
--- a/node/atarchiver.cp.lsst.org.yaml
+++ b/node/atarchiver.cp.lsst.org.yaml
@@ -16,3 +16,7 @@ nfs::client_mounts:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"
     atboot: true
+  /net/home:
+    share: "home"
+    server: "nfs1.cp.lsst.org"
+    atboot: true

--- a/node/atarchiver.cp.lsst.org.yaml
+++ b/node/atarchiver.cp.lsst.org.yaml
@@ -1,0 +1,10 @@
+---
+classes:
+  - "profile::core::nfsclient"
+
+nfs::client_enabled: true
+nfs::client_mounts:
+  /net/lsstdata:
+    share: "lsstdata"
+    server: "nfs1.cp.lsst.org"
+    atboot: true

--- a/node/atarchiver.cp.lsst.org.yaml
+++ b/node/atarchiver.cp.lsst.org.yaml
@@ -4,6 +4,14 @@ classes:
 
 nfs::client_enabled: true
 nfs::client_mounts:
+  /net/project:
+    share: "project"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
+  /net/scratch:
+    share: "scratch"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
   /net/lsstdata:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"

--- a/node/ts-csc-generic-01.cp.lsst.org.yaml
+++ b/node/ts-csc-generic-01.cp.lsst.org.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
-  "network"
+  - "profile::core::nfsclient"
+#  - "network"
 
 network::mroutes_hash:
   p2p1:
@@ -10,3 +11,18 @@ network::mroutes_hash:
     routes:
       "139.229.178.0/24": "139.229.170.254"
       "139.229.167.0/24": "139.229.170.254"
+
+nfs::client_enabled: true
+nfs::client_mounts:
+  /net/project:
+    share: "project"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
+  /net/scratch:
+    share: "scratch"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
+  /net/lsstdata:
+    share: "lsstdata"
+    server: "nfs1.cp.lsst.org"
+    atboot: true

--- a/node/ts-csc-generic-01.cp.lsst.org.yaml
+++ b/node/ts-csc-generic-01.cp.lsst.org.yaml
@@ -30,4 +30,3 @@ nfs::client_mounts:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"
     atboot: true
-    options_nfsv4: "ro,tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3"

--- a/node/ts-csc-generic-01.cp.lsst.org.yaml
+++ b/node/ts-csc-generic-01.cp.lsst.org.yaml
@@ -12,6 +12,8 @@ network::mroutes_hash:
       "139.229.178.0/24": "139.229.170.254"
       "139.229.167.0/24": "139.229.170.254"
 
+nfs::nfs_v4: true
+nfs::nfs_v4_idmap_domain: "%{::domain}"
 nfs::client_enabled: true
 nfs::client_mounts:
   /net/project:
@@ -26,3 +28,4 @@ nfs::client_mounts:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"
     atboot: true
+    options_nfsv4: "ro,tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3"

--- a/node/ts-csc-generic-01.cp.lsst.org.yaml
+++ b/node/ts-csc-generic-01.cp.lsst.org.yaml
@@ -1,7 +1,7 @@
 ---
 classes:
   - "profile::core::nfsclient"
-#  - "network"
+  - "network"
 
 network::mroutes_hash:
   p2p1:

--- a/node/ts-csc-generic-01.cp.lsst.org.yaml
+++ b/node/ts-csc-generic-01.cp.lsst.org.yaml
@@ -12,8 +12,6 @@ network::mroutes_hash:
       "139.229.178.0/24": "139.229.170.254"
       "139.229.167.0/24": "139.229.170.254"
 
-nfs::nfs_v4: true
-nfs::nfs_v4_idmap_domain: "%{::domain}"
 nfs::client_enabled: true
 nfs::client_mounts:
   /net/project:
@@ -22,6 +20,10 @@ nfs::client_mounts:
     atboot: true
   /net/scratch:
     share: "scratch"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
+  /net/home:
+    share: "home"
     server: "nfs1.cp.lsst.org"
     atboot: true
   /net/lsstdata:

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -180,4 +180,5 @@ accounts::user_list:
 # Use NFSv4 on NFS enabled hosts.
 # @see site/cp/role/nfsserver.yaml
 nfs::nfs_v4: true
+nfs::nfs_v4_client: true
 nfs::nfs_v4_idmap_domain: "%{::domain}"

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -176,3 +176,8 @@ accounts::user_list:
     ensure: "absent"
     managehome: true
     purge_user_home: true
+
+# Use NFSv4 on NFS enabled hosts.
+# @see site/cp/role/nfsserver.yaml
+nfs::nfs_v4: true
+nfs::nfs_v4_idmap_domain: "%{::domain}"

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -2,15 +2,36 @@
 classes:
   - "profile::core::common"
   - "profile::core::nfsserver"
-nfs::server_enabled: true
-nfs::client_enabled: false
+  - "profile::core::nfsclient"
+
+# NFS client and server
 nfs::nfs_v4: true
 nfs::nfs_v4_idmap_domain: "%{::domain}"
-nfs::nfs_v4_export_root: "/export"
-nfs::nfsv4_bindmount_enable: true
+
+# Server configuration
+nfs::server_enabled: true
 nfs::nfs_v4_export_root_clients: "139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)"
 nfs::nfs_exports_global:
-  /data/home: {}
-  /data/lsstdata: {}
-  /data/project: {}
-  /data/scratch: {}
+  /data/home: &exportopts
+    clients: "139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)"
+  /data/lsstdata:
+    <<: *exportopts
+  /data/project:
+    <<: *exportopts
+  /data/scratch:
+    <<: *exportopts
+
+nfs::client_enabled: true
+nfs::client_mounts:
+  /net/project:
+    share: "project"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
+  /net/scratch:
+    share: "scratch"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
+  /net/lsstdata:
+    share: "lsstdata"
+    server: "nfs1.cp.lsst.org"
+    atboot: true

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -31,3 +31,4 @@ nfs::client_mounts:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"
     atboot: true
+    options_nfsv4: "ro,tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3"

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -4,10 +4,6 @@ classes:
   - "profile::core::nfsserver"
   - "profile::core::nfsclient"
 
-# NFS client and server
-nfs::nfs_v4: true
-nfs::nfs_v4_idmap_domain: "%{::domain}"
-
 # Server configuration
 nfs::server_enabled: true
 nfs::nfs_v4_export_root_clients: "139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)"

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -1,0 +1,16 @@
+---
+classes:
+  - "profile::core::common"
+  - "profile::core::nfsserver"
+nfs::server_enabled: true
+nfs::client_enabled: false
+nfs::nfs_v4: true
+nfs::nfs_v4_idmap_domain: "%{::domain}"
+nfs::nfs_v4_export_root: "/export"
+nfs::nfsv4_bindmount_enable: true
+nfs::nfs_v4_export_root_clients: "139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)"
+nfs::nfs_exports_global:
+  /data/home: {}
+  /data/lsstdata: {}
+  /data/project: {}
+  /data/scratch: {}

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -27,6 +27,10 @@ nfs::client_mounts:
     share: "scratch"
     server: "nfs1.cp.lsst.org"
     atboot: true
+  /net/home:
+    share: "home"
+    server: "nfs1.cp.lsst.org"
+    atboot: true
   /net/lsstdata:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -8,14 +8,14 @@ classes:
 nfs::server_enabled: true
 nfs::nfs_v4_export_root_clients: "139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)"
 nfs::nfs_exports_global:
-  /data/home: &exportopts
+  /data/home:
     clients: "139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)"
   /data/lsstdata:
-    <<: *exportopts
+    clients: "139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash) atarchiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)"
   /data/project:
-    <<: *exportopts
+    clients: "139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)"
   /data/scratch:
-    <<: *exportopts
+    clients: "139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)"
 
 nfs::client_enabled: true
 nfs::client_mounts:

--- a/site/cp/role/nfsserver.yaml
+++ b/site/cp/role/nfsserver.yaml
@@ -11,7 +11,10 @@ nfs::nfs_exports_global:
   /data/home:
     clients: "139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)"
   /data/lsstdata:
-    clients: "139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash) atarchiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)"
+    clients: >-
+      139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      atarchiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.170.21(rw,nohide,insecure,no_subtree_check,async,root_squash)
   /data/project:
     clients: "139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)"
   /data/scratch:


### PR DESCRIPTION
This prototypes out NFS exports and mounts for nfs1, ts-csc-generic-01, and atarchiver.

This pull request does not implement Kerberos. It might be useful (as NFS has
hilariously weak security) but NFS + Kerberos appears to be nontrivial.

See also: https://github.com/lsst-it/lsst-itconf/pull/25