### PR TITLE
IT-1734: Direct query logs to local6 log facility

### DIFF
--- a/cluster/corecp/role/dnscache.yaml
+++ b/cluster/corecp/role/dnscache.yaml
@@ -23,7 +23,7 @@ dns::additional_directives:
   - "    channel queries_syslog {"
   - "        severity info;"
   - "        print-category yes;"
-  - "        syslog daemon;"
+  - "        syslog local6;"
   - "    };"
   - ""
   - "    category queries {"

--- a/site/cp.yaml
+++ b/site/cp.yaml
@@ -49,9 +49,12 @@ rsyslog::config::actions:
       Protocol: "udp"
   # Log anything (except mail) of level info or higher.
   # Don't log private authentication messages!
+  #
+  # local6 is used for logs that should only be forwarded to a central log
+  # server and should never be stored locally. See IT-1734.
   messages:
     type: "omfile"
-    facility: "*.info;mail.none;authpriv.none;cron.none"
+    facility: "*.info;mail.none;authpriv.none;cron.none;local6.none"
     config:
       file: "/var/log/messages"
   # The authpriv file has restricted access.


### PR DESCRIPTION
We had a minor outage because named queries filled up the hard drive on
dns1. This commit prevents the issue from recurring by directing named
query logs to `local6` and blocks those logs from making it to
`/var/log/messages`.